### PR TITLE
Feature: Add ETA for next level to XP Tracker

### DIFF
--- a/XPTracker.js
+++ b/XPTracker.js
@@ -1,6 +1,6 @@
 (function () {
   const TRACKING_TIME_MINUTES = [60, 60 * 6]; // modify here for different breakdowns, multiple is OK
-  const MS_ACCURACY = 20 * 1000; // polling interval in milliseconds for xp checks
+  const MS_ACCURACY = 5 * 1000; // polling interval in milliseconds for xp checks
   const INCLUDE_UI = true; // whether or not to add the tracker UI to the header
   const ID_PREFIX = 'shamsup-xp-tracker';
 


### PR DESCRIPTION
Closes #3 

- adds an `ETA` tab to the XP Tracker that will estimate the amount of time required to reach the next level for each tracked skill
- updates the xp polling frequency to 5 seconds

Each skill has its own tracking window to base the prediction off of.

Combat:
- attack, strength, defence, ranged, and magic are 10 minutes
- hp, prayer, and slayer are 20 minutes

Non-combat:
- fishing and thieving are 10 minutes
- farming is 6 hours 😄 
- the rest are 5 minutes